### PR TITLE
log -> logrus

### DIFF
--- a/main.go
+++ b/main.go
@@ -6,7 +6,7 @@ package main
 import (
 	"context"
 	"flag"
-	"log"
+	log "github.com/sirupsen/logrus"
 
 	"github.com/hashicorp/terraform-plugin-framework/providerserver"
 


### PR DESCRIPTION
Use logrus for logging instead of standard log library

[_Created by Sourcegraph batch change `admin/use-logrus-in-terraform-providers`._](https://gcp.s0urcegraph.com/users/admin/batch-changes/use-logrus-in-terraform-providers)